### PR TITLE
use gsudo as sudo.ps1 does not support code blocks

### DIFF
--- a/scoop-backup.ps1
+++ b/scoop-backup.ps1
@@ -88,10 +88,10 @@ if(($apps | Measure-Object).Count -gt 0) {
 # next, we install global apps
 $globals = installed_apps $true
 if(($globals | Measure-Object).Count -gt 0) {
-    append 'scoop install main/sudo'
+    append 'scoop install main/gsudo'
 
     # installing each app on a new line is, unfortunately, more resilient
-    append ("sudo powershell -Command {`nscoop install --global " + (($globals | ForEach-Object {
+    append ("gsudo powershell -Command {`nscoop install --global " + (($globals | ForEach-Object {
         $info = install_info $_ (Select-CurrentVersion -AppName $_ -Global:$true) $true
         if($info.url) { $($info.url) } else { "$($info.bucket)/$_" }
     }) -Join "`nscoop install --global ") + "`n}")


### PR DESCRIPTION
sudo.ps1 does have limitations regarding the passed command; it escaping function mangles {}, $ and some other characters
https://github.com/lukesampson/psutils/issues/42
https://github.com/lukesampson/psutils/issues/25

see https://github.com/lukesampson/psutils/blob/8af01127a949c64ea50b657989a4cd7744d4fffd/sudo.ps1#L40

using main/gsudo (https://github.com/gerardog/gsudo) works better